### PR TITLE
Add numpy wrapper to X, Y, Z

### DIFF
--- a/enzynet/visualization.py
+++ b/enzynet/visualization.py
@@ -125,7 +125,7 @@ def cuboid_data(pos, size=(1,1,1)):
          [o[2], o[2], o[2] + h, o[2] + h, o[2]],
          [o[2], o[2], o[2] + h, o[2] + h, o[2]]]
 
-    return x, y, z
+    return np.array(x), np.array(y), np.array(z)
 
 def plot_cube_at(pos=(0,0,0), ax=None):
     'Plots a cube element at position pos'


### PR DESCRIPTION
Solve the following errors:
```
Traceback (most recent call last):
  File "visualization.py", line 180, in <module>
    visualize_pdb('2Q3Z', p=0, v_size=32, weights=None)
  File "visualization.py", line 41, in visualize_pdb
    plot_volume(volume, pdb_id, v_size, num, weights=weights)
  File "visualization.py", line 67, in plot_volume
    plot_matrix(ax, volume)
  File "visualization.py", line 148, in plot_matrix
    plot_cube_at(pos=(i-0.5,j-0.5,k-0.5), ax=ax)
  File "visualization.py", line 134, in plot_cube_at
    ax.plot_surface(X, Y, Z, color='g', rstride=1, cstride=1, alpha=1)
  File "/anaconda3/lib/python3.6/site-packages/mpl_toolkits/mplot3d/axes3d.py", line 1635, in plot_surface
    if Z.ndim != 2:
AttributeError: 'list' object has no attribute 'ndim'
```