### PR TITLE
round up the number of batches per epoch

### DIFF
--- a/enzynet/volume.py
+++ b/enzynet/volume.py
@@ -152,7 +152,7 @@ class VolumeDataGenerator(keras.utils.Sequence):
 
     def __len__(self) -> int:
         """Denotes the number of batches per epoch."""
-        return int(np.floor(len(self.list_enzymes) / self.batch_size))
+        return int(np.ceil(len(self.list_enzymes) / self.batch_size))
 
     def __getitem__(self, index: int) -> Tuple[np.ndarray, np.ndarray]:
         """Generate one batch of data."""


### PR DESCRIPTION
Instead of np.floor, I think np.ceil is the right form of rounding to use. this is with reference to the tensorflow/keras documentation (https://www.tensorflow.org/api_docs/python/tf/keras/utils/Sequence)

Example explanation:
given a sample size (or the length of list_enzymes in this context) of 35 and a batch_size of 10, using np.floor will result in 3 batches. This leaves out the remaining 5 samples in the list_enzymes. meanwhile, using the ceil will result in 4 batches which covers the last 5 samples. You may be wondering about indexing in __getitem__ but since the self.indexes is a numpy array, indexing beyond the length of that array will just truncate at the end of the arra.